### PR TITLE
Enforce import style with GCI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
+    - goimports         # rely on gci instead
     - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
     - ifshort           # deprecated by author


### PR DESCRIPTION
We're already using GCI (since we default to using all available linters), so
there's no need for `goimports`. We're landing the same change in Buf, core,
and the other Go repos.
