### PR TITLE
Update refs for conformance repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ more customizable attribute filtering, use
 * [connect-kotlin]: Kotlin clients for idiomatic gRPC & Connect RPC
 * [connect-es]: Type-safe APIs with Protobuf and TypeScript.
 * [Buf Studio]: web UI for ad-hoc RPCs
-* [connect-conformance]: gRPC and gRPC-Web interoperability tests
+* [conformance]: Connect, gRPC, and gRPC-Web interoperability tests
 
 ## Support and Versioning
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Offered under the [Apache 2 license][license].
 [WithTrustRemote]: https://pkg.go.dev/connectrpc.com/otelconnect#WithTrustRemote
 [WithoutServerPeerAttributes]: https://pkg.go.dev/connectrpc.com/otelconnect#WithoutServerPeerAttributes
 [blog]: https://buf.build/blog/connect-a-better-grpc
-[connect-conformance]: https://github.com/connectrpc/conformance
+[conformance]: https://github.com/connectrpc/conformance
 [connect]: https://github.com/connectrpc/connect-go
 [connect-kotlin]: https://github.com/bufbuild/connect-kotlin
 [connect-swift]: https://github.com/bufbuild/connect-swift

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ more customizable attribute filtering, use
 * [connect-go][connect]: Service handlers and clients for Go
 * [connect-swift]: Swift clients for idiomatic gRPC & Connect RPC
 * [connect-kotlin]: Kotlin clients for idiomatic gRPC & Connect RPC
-* [connect-web]: TypeScript clients for web browsers
+* [connect-es]: Type-safe APIs with Protobuf and TypeScript.
 * [Buf Studio]: web UI for ad-hoc RPCs
-* [connect-crosstest]: gRPC and gRPC-Web interoperability tests
+* [connect-conformance]: gRPC and gRPC-Web interoperability tests
 
 ## Support and Versioning
 
@@ -123,11 +123,11 @@ Offered under the [Apache 2 license][license].
 [WithTrustRemote]: https://pkg.go.dev/connectrpc.com/otelconnect#WithTrustRemote
 [WithoutServerPeerAttributes]: https://pkg.go.dev/connectrpc.com/otelconnect#WithoutServerPeerAttributes
 [blog]: https://buf.build/blog/connect-a-better-grpc
-[connect-crosstest]: https://github.com/bufbuild/connect-crosstest
+[connect-conformance]: https://github.com/connectrpc/conformance
 [connect]: https://github.com/connectrpc/connect-go
 [connect-kotlin]: https://github.com/bufbuild/connect-kotlin
 [connect-swift]: https://github.com/bufbuild/connect-swift
-[connect-web]: https://www.npmjs.com/package/@bufbuild/connect-web
+[connect-es]: https://github.com/connectrpc/connect-es
 [docs]: https://connectrpc.com
 [go-support-policy]: https://golang.org/doc/devel/release#policy
 [godoc]: https://pkg.go.dev/connectrpc.com/otelconnect


### PR DESCRIPTION
This updates links to point to the new conformance repo (fka crosstests).

Note - not intended to merge until the conformance repo is moved.