### PR TITLE
Close ClientStreaming on context cancellation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,7 @@ linters:
     - maintidx          # covered by gocyclo
     - maligned          # readability trumps efficient struct packing
     - nlreturn          # generous whitespace violates house style
+    - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
     - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
     - scopelint         # deprecated by author
     - structcheck       # abandoned

--- a/context.go
+++ b/context.go
@@ -1,0 +1,25 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.21
+
+package otelconnect
+
+import "context"
+
+// afterFunc calls context.AfterFunc. Build tags ensure that this function
+// is only compiled when the Go version is at least 1.21.
+func afterFunc(ctx context.Context, f func()) (stop func() bool) {
+	return context.AfterFunc(ctx, f)
+}

--- a/context_legacy.go
+++ b/context_legacy.go
@@ -1,0 +1,38 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.21
+
+package otelconnect
+
+import (
+	"context"
+	"sync"
+)
+
+// afterFunc is a simple imitation of context.AfterFunc from Go 1.21.
+// It is not as efficient as the real implementation, but it is sufficient
+// for our purposes.
+func afterFunc2(ctx context.Context, f func()) (stop func() bool) {
+	var once sync.Once
+	go func() {
+		<-ctx.Done()
+		once.Do(f)
+	}()
+	return func() bool {
+		var didStop bool
+		once.Do(func() { didStop = true })
+		return didStop
+	}
+}

--- a/context_legacy.go
+++ b/context_legacy.go
@@ -24,7 +24,7 @@ import (
 // afterFunc is a simple imitation of context.AfterFunc from Go 1.21.
 // It is not as efficient as the real implementation, but it is sufficient
 // for our purposes.
-func afterFunc2(ctx context.Context, f func()) (stop func() bool) {
+func afterFunc(ctx context.Context, f func()) (stop func() bool) {
 	var once sync.Once
 	go func() {
 		<-ctx.Done()

--- a/context_legacy.go
+++ b/context_legacy.go
@@ -25,6 +25,7 @@ import (
 // It is not as efficient as the real implementation, but it is sufficient
 // for our purposes.
 func afterFunc(ctx context.Context, f func()) (stop func() bool) {
+	ctx, cancel := context.WithCancel(ctx)
 	var once sync.Once
 	go func() {
 		<-ctx.Done()
@@ -32,7 +33,10 @@ func afterFunc(ctx context.Context, f func()) (stop func() bool) {
 	}()
 	return func() bool {
 		var didStop bool
-		once.Do(func() { didStop = true })
+		once.Do(func() {
+			didStop = true
+			cancel()
+		})
 		return didStop
 	}
 }

--- a/payloadinterceptor.go
+++ b/payloadinterceptor.go
@@ -34,10 +34,6 @@ func (s *streamingClientInterceptor) Send(msg any) error {
 	return s.send(msg, s.StreamingClientConn)
 }
 
-func (s *streamingClientInterceptor) CloseRequest() error {
-	return s.StreamingClientConn.CloseRequest()
-}
-
 func (s *streamingClientInterceptor) CloseResponse() error {
 	err := s.StreamingClientConn.CloseResponse()
 	s.onClose()


### PR DESCRIPTION
CloseRequest and CloseResponse must both be called before the span can be ended. Remove onCloseCalled bool as it's easy to derive.

### Updates

On `CloseResponse` we must have stopped the connection and it is now safe to close the span. To handle context cancellation and ensure the span is always closed [`context.AfterFunc`](https://pkg.go.dev/context#AfterFunc) is added with a simpler backport for !go1.21.