### PR TITLE
Remove *Request to fix streaming client context

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -29,9 +29,9 @@ import (
 // AttributeFilter is used to filter attributes out based on the [Request] and [attribute.KeyValue].
 // If the filter returns true the attribute will be kept else it will be removed.
 // AttributeFilter must be safe to call concurrently.
-type AttributeFilter func(*Request, attribute.KeyValue) bool
+type AttributeFilter func(connect.Spec, attribute.KeyValue) bool
 
-func (filter AttributeFilter) filter(request *Request, values ...attribute.KeyValue) []attribute.KeyValue {
+func (filter AttributeFilter) filter(spec connect.Spec, values ...attribute.KeyValue) []attribute.KeyValue {
 	if filter == nil {
 		return values
 	}
@@ -39,7 +39,7 @@ func (filter AttributeFilter) filter(request *Request, values ...attribute.KeyVa
 	// array as the values slice. This avoids unnecessary memory allocations.
 	filteredValues := values[:0]
 	for _, attr := range values {
-		if filter(request, attr) {
+		if filter(spec, attr) {
 			filteredValues = append(filteredValues, attr)
 		}
 	}
@@ -71,13 +71,13 @@ func procedureAttributes(procedure string) []attribute.KeyValue {
 	return attrs
 }
 
-func requestAttributes(req *Request) []attribute.KeyValue {
+func requestAttributes(spec connect.Spec, peer connect.Peer) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
-	if addr := req.Peer.Addr; addr != "" {
+	if addr := peer.Addr; addr != "" {
 		attrs = append(attrs, addressAttributes(addr)...)
 	}
-	name := strings.TrimLeft(req.Spec.Procedure, "/")
-	protocol := protocolToSemConv(req.Peer.Protocol)
+	name := strings.TrimLeft(spec.Procedure, "/")
+	protocol := protocolToSemConv(peer.Protocol)
 	attrs = append(attrs, semconv.RPCSystemKey.String(protocol))
 	attrs = append(attrs, procedureAttributes(name)...)
 	return attrs

--- a/attributes.go
+++ b/attributes.go
@@ -26,9 +26,9 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
-// AttributeFilter is used to filter attributes out based on the [Request] and [attribute.KeyValue].
-// If the filter returns true the attribute will be kept else it will be removed.
-// AttributeFilter must be safe to call concurrently.
+// AttributeFilter is used to filter attributes out based on the [connect.Spec]
+// and [attribute.KeyValue]. If the filter returns true the attribute will be
+// kept else it will be removed. AttributeFilter must be safe to call concurrently.
 type AttributeFilter func(connect.Spec, attribute.KeyValue) bool
 
 func (filter AttributeFilter) filter(spec connect.Spec, values ...attribute.KeyValue) []attribute.KeyValue {

--- a/interceptor.go
+++ b/interceptor.go
@@ -195,7 +195,6 @@ func (i *Interceptor) WrapStreamingClient(next connect.StreamingClientFunc) conn
 			name,
 			trace.WithSpanKind(trace.SpanKindClient),
 		)
-
 		conn := next(ctx, spec)
 		instrumentation := i.getInstruments(spec.IsClient)
 		if i.config.filter != nil {

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1016,7 +1016,7 @@ func TestClientHandlerOpts(t *testing.T) {
 	clientTraceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(clientSpanRecorder))
 	serverInterceptor, err := NewInterceptor(
 		WithTracerProvider(serverTraceProvider),
-		WithFilter(func(ctx context.Context, request *Request) bool {
+		WithFilter(func(ctx context.Context, spec connect.Spec) bool {
 			return false
 		}),
 	)
@@ -1073,7 +1073,7 @@ func TestBasicFilter(t *testing.T) {
 	headerKey, headerVal := "Some-Header", "foobar"
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
-	serverInterceptor, err := NewInterceptor(WithTracerProvider(traceProvider), WithFilter(func(ctx context.Context, request *Request) bool {
+	serverInterceptor, err := NewInterceptor(WithTracerProvider(traceProvider), WithFilter(func(ctx context.Context, spec connect.Spec) bool {
 		return false
 	}))
 	require.NoError(t, err)
@@ -1089,58 +1089,6 @@ func TestBasicFilter(t *testing.T) {
 		t.Error("unexpected spans recorded")
 	}
 	assertSpans(t, []wantSpans{}, spanRecorder.Ended())
-}
-
-func TestFilterHeader(t *testing.T) {
-	t.Parallel()
-	headerKey, headerVal := "Some-Header", "foobar"
-	spanRecorder := tracetest.NewSpanRecorder()
-	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
-	serverInterceptor, err := NewInterceptor(WithTracerProvider(traceProvider), WithFilter(func(ctx context.Context, request *Request) bool {
-		return request.Header.Get(headerKey) == headerVal
-	}))
-	require.NoError(t, err)
-	pingClient, host, port := startServer([]connect.HandlerOption{
-		connect.WithInterceptors(serverInterceptor),
-	}, nil, okayPingServer())
-	req := requestOfSize(1, 0)
-	req.Header().Set(headerKey, headerVal)
-	if _, err := pingClient.Ping(context.Background(), req); err != nil {
-		t.Errorf(err.Error())
-	}
-	if _, err := pingClient.Ping(context.Background(), requestOfSize(1, 0)); err != nil {
-		t.Errorf(err.Error())
-	}
-	assertSpans(t, []wantSpans{
-		{
-			spanName: pingv1connect.PingServiceName + "/" + PingMethod,
-			events: []trace.Event{
-				{
-					Name: messageKey,
-					Attributes: []attribute.KeyValue{
-						semconv.MessageTypeReceived,
-						semconv.MessageIDKey.Int(1),
-						semconv.MessageUncompressedSizeKey.Int(2),
-					},
-				},
-				{
-					Name: messageKey,
-					Attributes: []attribute.KeyValue{
-						semconv.MessageTypeSent,
-						semconv.MessageIDKey.Int(1),
-						semconv.MessageUncompressedSizeKey.Int(2),
-					},
-				},
-			},
-			attrs: []attribute.KeyValue{
-				semconv.NetPeerNameKey.String(host),
-				semconv.NetPeerPortKey.Int(port),
-				semconv.RPCSystemKey.String(bufConnect),
-				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
-				semconv.RPCMethodKey.String(PingMethod),
-			},
-		},
-	}, spanRecorder.Ended())
 }
 
 func TestHeaderAttribute(t *testing.T) {
@@ -1767,7 +1715,7 @@ func TestWithAttributeFilter(t *testing.T) {
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
 	clientInterceptor, err := NewInterceptor(
 		WithTracerProvider(traceProvider),
-		WithAttributeFilter(func(_ *Request, value attribute.KeyValue) bool {
+		WithAttributeFilter(func(_ connect.Spec, value attribute.KeyValue) bool {
 			if value.Key == semconv.MessageIDKey {
 				return false
 			}

--- a/option.go
+++ b/option.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/http"
 
+	connect "connectrpc.com/connect"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -54,7 +55,7 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 
 // WithFilter configures the instrumentation to emit traces and metrics only
 // when the filter function returns true. Filter functions must be safe to call concurrently.
-func WithFilter(filter func(context.Context, *Request) bool) Option {
+func WithFilter(filter func(context.Context, connect.Spec) bool) Option {
 	return &filterOption{filter}
 }
 
@@ -79,8 +80,8 @@ func WithAttributeFilter(filter AttributeFilter) Option {
 // high-cardinality data; this option significantly reduces cardinality in most
 // environments.
 func WithoutServerPeerAttributes() Option {
-	return WithAttributeFilter(func(request *Request, value attribute.KeyValue) bool {
-		if request.Spec.IsClient {
+	return WithAttributeFilter(func(spec connect.Spec, value attribute.KeyValue) bool {
+		if spec.IsClient {
 			return true
 		}
 		if value.Key == semconv.NetPeerPortKey {
@@ -158,7 +159,7 @@ func (o *tracerProviderOption) apply(c *config) {
 }
 
 type filterOption struct {
-	filter func(context.Context, *Request) bool
+	filter func(context.Context, connect.Spec) bool
 }
 
 func (o *filterOption) apply(c *config) {

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -16,7 +16,6 @@ package otelconnect
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	connect "connectrpc.com/connect"
@@ -36,17 +35,8 @@ const (
 	connectProtocol     = "connect_rpc"
 )
 
-// Request is the information about each RPC available to filter functions. It
-// contains the common subset of [connect.AnyRequest],
-// [connect.StreamingClientConn], and [connect.StreamingHandlerConn].
-type Request struct {
-	Spec   connect.Spec
-	Peer   connect.Peer
-	Header http.Header
-}
-
 type config struct {
-	filter             func(context.Context, *Request) bool
+	filter             func(context.Context, connect.Spec) bool
 	filterAttribute    AttributeFilter
 	meter              metric.Meter
 	tracer             trace.Tracer


### PR DESCRIPTION
Context in client streams doesn't include the span due to the `*Request` requiring information only included once the connection is created. This PR proposes removing the `*Request` in favour of simply providing the `connect.Spec` information. Now we can correctly initialize the span creation before passing the context to the client handler.

### Changes
- Removes exported `*Request` object (breaking change)
- Changes option filters to use `connect.Spec` instead of `*Request` (breaking change)