### PR TITLE
Fix merge conflict on descriptions

### DIFF
--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -679,8 +679,9 @@ func TestStreamingMetricsFail(t *testing.T) {
 						},
 					},
 					{
-						Name: rpcServerResponsesPerRPC,
-						Unit: unitDimensionless,
+						Name:        rpcServerResponsesPerRPC,
+						Description: responsesPerRPCDesc,
+						Unit:        unitDimensionless,
 						Data: metricdata.Histogram[int64]{
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{


### PR DESCRIPTION
Fixes the missing description in a test causing CI failures. Due to a merge issue. See CI failures here: https://github.com/connectrpc/otelconnect-go/actions/runs/7117347326