### PR TITLE
Bump Go to v1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x,1.20.x,1.21.x]
+        go-version: [1.20.x,1.21.x,1.22.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Test
@@ -30,5 +30,5 @@ jobs:
       - name: Lint
         # Often, lint & gofmt guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
-        if: matrix.go-version == '1.21.x'
+        if: matrix.go-version == '1.22.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,7 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - deadcode          # abandoned
-    - depguard          # requires customization to use non-stdlib
+    - depguard          # unnecessary for small libraries
     - exhaustivestruct  # replaced by exhaustruct
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
@@ -46,6 +46,7 @@ linters:
     - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
     - ifshort           # deprecated by author
+    - inamedparam       # convention is not followed
     - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
@@ -54,13 +55,13 @@ linters:
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
     - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
+    - protogetter       # too many false positives
     - scopelint         # deprecated by author
     - structcheck       # abandoned
     - testpackage       # internal tests are fine
     - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
-    - inamedparam       # convention is not followed
 issues:
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining

--- a/Makefile
+++ b/Makefile
@@ -80,16 +80,16 @@ $(BIN)/protoc-gen-connect-go: go.mod
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.27.2
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.29.0
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.27.2
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.29.0
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
 
 $(BIN)/protoc-gen-go: Makefile
 	@mkdir -p $(@D)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/otelconnect
 
-go 1.19
+go 1.20
 
 require (
 	connectrpc.com/connect v1.14.0

--- a/interceptor.go
+++ b/interceptor.go
@@ -195,7 +195,8 @@ func (i *Interceptor) WrapStreamingClient(next connect.StreamingClientFunc) conn
 		}
 		requestStartTime := i.config.now()
 		name := strings.TrimLeft(spec.Procedure, "/")
-		ctx, span := i.config.tracer.Start(
+		// Span is closed on context cancelation or when the stream is closed.
+		ctx, span := i.config.tracer.Start( //nolint:spancheck
 			ctx,
 			name,
 			trace.WithSpanKind(trace.SpanKindClient),
@@ -247,7 +248,7 @@ func (i *Interceptor) WrapStreamingClient(next connect.StreamingClientFunc) conn
 				metric.WithAttributes(state.attributes...))
 		}
 		stopCtxClose := afterFunc(ctx, closeSpan)
-		return &streamingClientInterceptor{
+		return &streamingClientInterceptor{ //nolint:spancheck
 			StreamingClientConn: conn,
 			onClose: func() {
 				if stopCtxClose() {

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1016,7 +1016,7 @@ func TestClientHandlerOpts(t *testing.T) {
 	clientTraceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(clientSpanRecorder))
 	serverInterceptor, err := NewInterceptor(
 		WithTracerProvider(serverTraceProvider),
-		WithFilter(func(ctx context.Context, spec connect.Spec) bool {
+		WithFilter(func(_ context.Context, _ connect.Spec) bool {
 			return false
 		}),
 	)
@@ -1073,7 +1073,7 @@ func TestBasicFilter(t *testing.T) {
 	headerKey, headerVal := "Some-Header", "foobar"
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
-	serverInterceptor, err := NewInterceptor(WithTracerProvider(traceProvider), WithFilter(func(ctx context.Context, spec connect.Spec) bool {
+	serverInterceptor, err := NewInterceptor(WithTracerProvider(traceProvider), WithFilter(func(_ context.Context, _ connect.Spec) bool {
 		return false
 	}))
 	require.NoError(t, err)
@@ -1401,7 +1401,6 @@ func TestUnaryInterceptorNotModifiedError(t *testing.T) {
 	t.Parallel()
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
-	var ctx context.Context
 	serverInterceptor, err := NewInterceptor(
 		WithPropagator(propagation.TraceContext{}),
 		WithTracerProvider(traceProvider),
@@ -1412,7 +1411,8 @@ func TestUnaryInterceptorNotModifiedError(t *testing.T) {
 		[]connect.HandlerOption{
 			connect.WithInterceptors(connect.UnaryInterceptorFunc(func(unaryFunc connect.UnaryFunc) connect.UnaryFunc {
 				return func(_ context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
-					ctx, _ = trace.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
+					ctx, span := trace.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
+					defer span.End()
 					return unaryFunc(ctx, request)
 				}
 			})),
@@ -1942,7 +1942,7 @@ func TestServerSpanStatus(t *testing.T) {
 		}, []connect.ClientOption{
 			connect.WithInterceptors(clientInterceptor),
 		}, &pluggablePingServer{
-			ping: func(ctx context.Context, r *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
+			ping: func(_ context.Context, _ *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
 				return nil, connect.NewError(testcase.connectCode, errors.New(testcase.connectCode.String()))
 			},
 		})
@@ -1980,7 +1980,7 @@ func TestStreamingServerSpanStatus(t *testing.T) {
 			}, []connect.ClientOption{
 				connect.WithInterceptors(clientInterceptor),
 			}, &pluggablePingServer{
-				pingStream: func(ctx context.Context, bs *connect.BidiStream[pingv1.PingStreamRequest, pingv1.PingStreamResponse]) error {
+				pingStream: func(_ context.Context, _ *connect.BidiStream[pingv1.PingStreamRequest, pingv1.PingStreamResponse]) error {
 					return connect.NewError(testcase.connectCode, errors.New(testcase.connectCode.String()))
 				},
 			})

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1410,8 +1410,8 @@ func TestUnaryInterceptorNotModifiedError(t *testing.T) {
 	client, _, _ := startServer(
 		[]connect.HandlerOption{
 			connect.WithInterceptors(connect.UnaryInterceptorFunc(func(unaryFunc connect.UnaryFunc) connect.UnaryFunc {
-				return func(_ context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
-					ctx, span := trace.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
+				return func(ctx context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
+					ctx, span := trace.NewTracerProvider().Tracer("test").Start(ctx, "test")
 					defer span.End()
 					return unaryFunc(ctx, request)
 				}


### PR DESCRIPTION
Increases min version to v1.20 and current v1.22. Also included is a lint bump with associated fixes.