### PR TITLE
Fix data race on streaming client close

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -228,6 +228,8 @@ func (i *Interceptor) WrapStreamingClient(next connect.StreamingClientFunc) conn
 		}
 		closeSpan := func() {
 			requestOnce.Do(setRequestAttributes)
+			state.mu.Lock()
+			defer state.mu.Unlock()
 			// state.attributes is updated with the final error that was recorded.
 			// If error is nil a "success" is recorded on the span and on the final duration
 			// metric. The "rpc.<protocol>.status_code" is not defined for any other metrics for

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -17,7 +17,6 @@ package otelconnect
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/rand"
 	"net"
 	"net/http"
@@ -1613,7 +1612,7 @@ func TestStreamingClientContextCancellation(t *testing.T) {
 	assertTraceParent := func(_ context.Context, stream *connect.BidiStream[pingv1.PingStreamRequest, pingv1.PingStreamResponse]) error {
 		assert.NotZero(t, stream.RequestHeader().Get(TraceParentKey))
 		require.NoError(t, stream.Send(msg))
-		return fmt.Errorf("stream closed") // Simulate error in stream.
+		return errors.New("stream closed") // Simulate error in stream.
 	}
 	clientInterceptor, err := NewInterceptor(
 		WithPropagator(propagation.TraceContext{}),
@@ -1633,8 +1632,8 @@ func TestStreamingClientContextCancellation(t *testing.T) {
 	assert.Equal(t, msg.GetData(), resp.GetData())
 	go cancel()               // Cancel the stream before the response is received.
 	_, err = stream.Receive() // Receive the end of the stream.
-	assert.Error(t, err)
-	assert.Nil(t, stream.CloseResponse())
+	require.Error(t, err)
+	assert.NoError(t, stream.CloseResponse())
 }
 
 func TestStreamingHandlerTracing(t *testing.T) {


### PR DESCRIPTION
Fix a data race for a streaming client on close when a the context is cancelled. This was introduced in #152 where we changed the behaviour to trigger a close on context cancellation. The state must be locked to avoid a data race with Send/Receive calls.

Closes #170, #171.