### PR TITLE
Use canonical header keys to extract needed header attributes

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -124,7 +124,8 @@ func statusCodeAttribute(protocol string, serverErr error) (attribute.KeyValue, 
 func headerAttributes(protocol, eventType string, metadata http.Header, allowedKeys []string) []attribute.KeyValue {
 	attributes := make([]attribute.KeyValue, 0, len(allowedKeys))
 	for _, allowedKey := range allowedKeys {
-		if val, ok := metadata[allowedKey]; ok {
+		val := metadata.Values(allowedKey)
+		if len(val) > 0 {
 			keyValue := attribute.StringSlice(
 				formatHeaderAttributeKey(protocol, eventType, allowedKey),
 				val,


### PR DESCRIPTION
When extracting headers from `http.Header`, it's better to use `Values` instead of accessing the map directly, since it canonicalizes the key before checking it. Many proxies and interceptors canonicalize header keys before forwarding them, so headers could have been omitted without this fix.