### PR TITLE
Add emcfarlane as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,7 @@ Maintainers
 ## Current
 * [Akshay Shah](https://github.com/akshayjshah), [Buf](https://buf.build)
 * [Josh Humphries](https://github.com/jhump), [Buf](https://buf.build)
+* [Edward McFarlane](https://github.com/emcfarlane), [Buf](https://buf.build)
 
 ## Former
 * [Josh Carpeggiani](https://github.com/joshcarp)


### PR DESCRIPTION
This proposes adding myself [emcfarlane](https://github.com/emcfarlane) as a maintainer, per [Connect's governance policy](https://connectrpc.com/docs/governance/project-governance).

CC @akshayjshah , @jhump.