### PR TITLE
Fixup links

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ more customizable attribute filtering, use
 Offered under the [Apache 2 license][license].
 
 [Buf Studio]: https://buf.build/studio
-[Getting Started]: https://connectrpc.com/docs/go/getting-started
 [WithFilter]: https://pkg.go.dev/connectrpc.com/otelconnect#WithFilter
 [WithTrustRemote]: https://pkg.go.dev/connectrpc.com/otelconnect#WithTrustRemote
 [WithoutServerPeerAttributes]: https://pkg.go.dev/connectrpc.com/otelconnect#WithoutServerPeerAttributes
@@ -138,10 +137,8 @@ Offered under the [Apache 2 license][license].
 [connect-swift]: https://github.com/connectrpc/connect-swift
 [connect-es]: https://github.com/connectrpc/connect-es
 [docs]: https://connectrpc.com
-[go-support-policy]: https://golang.org/doc/devel/release#policy
+[go-support-policy]: https://go.dev/doc/devel/release#policy
 [godoc]: https://pkg.go.dev/connectrpc.com/otelconnect
 [license]: https://github.com/connectrpc/otelconnect-go/blob/main/LICENSE
 [opentelemetry.io]: https://opentelemetry.io/
-[otel-go-quickstart]: https://opentelemetry.io/docs/instrumentation/go/getting-started/
-[otel-go]: https://github.com/open-telemetry/opentelemetry-go
-[otel-rpc-conventions]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/README.md
+[otel-rpc-conventions]: https://opentelemetry.io/docs/specs/semconv/rpc/

--- a/doc.go
+++ b/doc.go
@@ -14,9 +14,11 @@
 
 // Package otelconnect provides OpenTelemetry tracing and metrics for
 // [connectrpc.com/connect] servers and clients.
-// The specification followed was the [OpenTelemetry specification] with both the [rpc metrics specification] and [rpc trace specification] implemented.
+// The specification followed was the [OpenTelemetry specification]
+// with both the [rpc metrics specification]
+// and [rpc spans specification] implemented.
 //
 // [OpenTelemetry specification]: https://github.com/open-telemetry/opentelemetry-specification
-// [rpc metrics specification]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/rpc-metrics.md
-// [rpc trace specification]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md
+// [rpc metrics specification]: https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/
+// [rpc spans specification]: https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/
 package otelconnect


### PR DESCRIPTION
Noticed that the links in doc.go weren't updated in #163, so tracked down what the best links for those documents are — also fixed up some links in the README.