### PR TITLE
Reduce unnecessary allocations in interceptors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   dupl:
     threshold: 200
@@ -19,8 +17,6 @@ linters-settings:
   importas:
     no-unaliased: true
     alias:
-      - pkg: connectrpc.com/connect
-        alias: connect
       - pkg: connectrpc.com/otelconnect/internal/gen/observability/ping/v1
         alias: pingv1
   godox:
@@ -37,12 +33,10 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
-    - execinquery       # deprecated since golangci v1.58
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - gomnd             # some unnamed constants are okay
     - inamedparam       # convention is not followed
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
@@ -51,10 +45,12 @@ linters:
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
     - protogetter       # too many false positives
+    - tenv              # replaced by usetesting
     - testpackage       # internal tests are fine
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2024 The Connect Authors
+   Copyright 2022-2025 The Connect Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
 BIN := $(abspath .tmp/bin)
-COPYRIGHT_YEARS := 2022-2024
+COPYRIGHT_YEARS := 2022-2025
 LICENSE_IGNORE := -e /gen/
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
@@ -80,16 +80,16 @@ $(BIN)/protoc-gen-connect-go: go.mod
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.45.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.50.0
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.45.0
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.50.0
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
 
 $(BIN)/protoc-gen-go: Makefile
 	@mkdir -p $(@D)

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -12,13 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package otelconnect provides OpenTelemetry tracing and metrics for
-// [connectrpc.com/connect] servers and clients.
-// The specification followed was the [OpenTelemetry specification]
-// with both the [rpc metrics specification]
-// and [rpc spans specification] implemented.
-//
-// [OpenTelemetry specification]: https://github.com/open-telemetry/opentelemetry-specification
-// [rpc metrics specification]: https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/
-// [rpc spans specification]: https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/
 package otelconnect
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestAttributeFilter(t *testing.T) {
+	t.Parallel()
+	filterOdd := AttributeFilter(func(_ connect.Spec, kv attribute.KeyValue) bool {
+		return kv.Value.AsInt64()%2 != 0
+	})
+	assert.Equal(t,
+		[]attribute.KeyValue{
+			attribute.Int64("one", 1),
+			attribute.Int64("three", 3),
+		},
+		filterOdd.filter(
+			connect.Spec{},
+			attribute.Int64("zero", 0),
+			attribute.Int64("one", 1),
+			attribute.Int64("two", 2),
+			attribute.Int64("three", 3),
+			attribute.Int64("four", 4),
+		))
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Connect Authors
+// Copyright 2022-2025 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	connect "connectrpc.com/connect"
+	"connectrpc.com/connect"
 	pingv1 "connectrpc.com/otelconnect/internal/gen/observability/ping/v1"
 	"connectrpc.com/otelconnect/internal/gen/observability/ping/v1/pingv1connect"
 )
@@ -59,6 +59,7 @@ func benchUnary(b *testing.B, handleropts []connect.HandlerOption, clientopts []
 	b.Helper()
 	svr, client := startBenchServer(handleropts, clientopts)
 	b.Cleanup(svr.Close)
+	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		ctx := context.Background()
@@ -76,6 +77,7 @@ func benchUnary(b *testing.B, handleropts []connect.HandlerOption, clientopts []
 func benchStreaming(b *testing.B, handleropts []connect.HandlerOption, clientopts []connect.ClientOption) {
 	b.Helper()
 	_, client := startBenchServer(handleropts, clientopts)
+	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		ctx := context.Background()

--- a/instruments.go
+++ b/instruments.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Connect Authors
+// Copyright 2022-2025 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Connect Authors
+// Copyright 2022-2025 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	connect "connectrpc.com/connect"
+	"connectrpc.com/connect"
 	pingv1 "connectrpc.com/otelconnect/internal/gen/observability/ping/v1"
 	"connectrpc.com/otelconnect/internal/gen/observability/ping/v1/pingv1connect"
 	"github.com/google/go-cmp/cmp"
@@ -441,7 +441,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 					{
 						Name:        rpcClientDuration,
 						Description: durationDesc,
-						Unit:        string("ms"),
+						Unit:        "ms",
 						Data: metricdata.Histogram[int64]{
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{

--- a/internal/gen/observability/ping/v1/ping.pb.go
+++ b/internal/gen/observability/ping/v1/ping.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Connect Authors
+// Copyright 2022-2025 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/observability/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/observability/ping/v1/pingv1connect/ping.connect.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Connect Authors
+// Copyright 2022-2025 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/proto/observability/ping/v1/ping.proto
+++ b/internal/proto/observability/ping/v1/ping.proto
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Connect Authors
+// Copyright 2022-2025 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/option.go
+++ b/option.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Connect Authors
+// Copyright 2022-2025 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import (
 	"context"
 	"net/http"
 
-	connect "connectrpc.com/connect"
+	"connectrpc.com/connect"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Connect Authors
+// Copyright 2022-2025 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	connect "connectrpc.com/connect"
+	"connectrpc.com/connect"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"

--- a/payloadinterceptor.go
+++ b/payloadinterceptor.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Connect Authors
+// Copyright 2022-2025 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 package otelconnect
 
 import (
-	connect "connectrpc.com/connect"
+	"connectrpc.com/connect"
 )
 
 type streamingClientInterceptor struct {

--- a/pingserver_test.go
+++ b/pingserver_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Connect Authors
+// Copyright 2022-2025 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import (
 	"io"
 	"net/http"
 
-	connect "connectrpc.com/connect"
+	"connectrpc.com/connect"
 	pingv1 "connectrpc.com/otelconnect/internal/gen/observability/ping/v1"
 	"connectrpc.com/otelconnect/internal/gen/observability/ping/v1/pingv1connect"
 )


### PR DESCRIPTION
Remove unnecessary allocations by pre-sizing slice allocations, reducing slice allocations in helper methods, and removing unused variables along the happy path (no errors).

Additionally switch to using `clear` to reset filtered out part of attribute slices since we're on Go 1.22, update license headers, and update golangci-lint.