### PR TITLE
Push both gRPC and Connect RPC attributes

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -86,9 +86,7 @@ func addAddressAttributes(attrs []attribute.KeyValue, address string) []attribut
 	return append(attrs, semconv.NetPeerNameKey.String(address))
 }
 
-func statusCodeAttributes(onStreaming bool, serverErr error) []attribute.KeyValue {
-	var attributes []attribute.KeyValue
-
+func addStatusCodeAttributes(attributes []attribute.KeyValue, onStreaming bool, serverErr error) []attribute.KeyValue {
 	if serverErr != nil {
 		if connect.IsNotModifiedError(serverErr) {
 			// A "not modified" error is special: it's code is technically "unknown" but

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -121,6 +121,7 @@ func TestStreamingMetrics(t *testing.T) {
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   1000.0,
@@ -190,6 +191,7 @@ func TestStreamingMetrics(t *testing.T) {
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   1,
@@ -213,6 +215,7 @@ func TestStreamingMetrics(t *testing.T) {
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   1,
@@ -285,6 +288,7 @@ func TestStreamingMetricsClient(t *testing.T) {
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   1000.0,
@@ -354,6 +358,7 @@ func TestStreamingMetricsClient(t *testing.T) {
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   1,
@@ -377,6 +382,7 @@ func TestStreamingMetricsClient(t *testing.T) {
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   1,
@@ -452,6 +458,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
 										attribute.Key(rpcBufConnectStatusCode).String("data_loss"),
+										semconv.RPCGRPCStatusCodeKey.Int64(int64(connect.CodeDataLoss)),
 									),
 									Count: 1,
 									Sum:   1000.0,
@@ -499,7 +506,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
-										attribute.Key(rpcBufConnectStatusCode).String("data_loss"),
+										semconv.RPCGRPCStatusCodeKey.Int64(int64(connect.CodeDataLoss)),
 									),
 									Count: 1,
 									Sum:   0.0,
@@ -524,6 +531,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
 										attribute.Key(rpcBufConnectStatusCode).String("data_loss"),
+										semconv.RPCGRPCStatusCodeKey.Int64(int64(connect.CodeDataLoss)),
 									),
 									Count: 1,
 									Sum:   1,
@@ -548,6 +556,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
 										attribute.Key(rpcBufConnectStatusCode).String("data_loss"),
+										semconv.RPCGRPCStatusCodeKey.Int64(int64(connect.CodeDataLoss)),
 									),
 									Count: 1,
 									Sum:   1,
@@ -623,6 +632,7 @@ func TestStreamingMetricsFail(t *testing.T) {
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
+										semconv.RPCGRPCStatusCodeKey.Int64(int64(connect.CodeDataLoss)),
 									),
 									Count: 1,
 									Sum:   1000.0,
@@ -670,6 +680,7 @@ func TestStreamingMetricsFail(t *testing.T) {
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
 										attribute.Key(rpcBufConnectStatusCode).String("data_loss"),
+										semconv.RPCGRPCStatusCodeKey.Int64(int64(connect.CodeDataLoss)),
 									),
 									Count: 1,
 									Sum:   1,
@@ -694,6 +705,7 @@ func TestStreamingMetricsFail(t *testing.T) {
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(PingStreamMethod),
 										attribute.Key(rpcBufConnectStatusCode).String("data_loss"),
+										semconv.RPCGRPCStatusCodeKey.Int64(int64(connect.CodeDataLoss)),
 									),
 									Count: 1,
 									Sum:   0,
@@ -760,6 +772,7 @@ func TestMetrics(t *testing.T) {
 										semconv.RPCMethodKey.String(PingMethod),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCSystemKey.String(bufConnect),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   time.Second.Milliseconds(),
@@ -783,6 +796,7 @@ func TestMetrics(t *testing.T) {
 										semconv.RPCMethodKey.String(PingMethod),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCSystemKey.String(bufConnect),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   16,
@@ -806,6 +820,7 @@ func TestMetrics(t *testing.T) {
 										semconv.RPCMethodKey.String(PingMethod),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCSystemKey.String(bufConnect),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   16,
@@ -829,6 +844,7 @@ func TestMetrics(t *testing.T) {
 										semconv.RPCMethodKey.String(PingMethod),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCSystemKey.String(bufConnect),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   1,
@@ -852,6 +868,7 @@ func TestMetrics(t *testing.T) {
 										semconv.RPCMethodKey.String(PingMethod),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCSystemKey.String(bufConnect),
+										semconv.RPCGRPCStatusCodeKey.Int64(0),
 									),
 									Count: 1,
 									Sum:   1,
@@ -955,6 +972,7 @@ func TestClientSimple(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingMethod),
+				semconv.RPCGRPCStatusCodeKey.Int64(0),
 			},
 		},
 	}, clientSpanRecorder.Ended())
@@ -1004,6 +1022,7 @@ func TestHandlerFailCall(t *testing.T) {
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(FailMethod),
 				attribute.Key(rpcBufConnectStatusCode).String(UnimplementedString),
+				semconv.RPCGRPCStatusCodeKey.Int64(int64(connect.CodeUnimplemented)),
 			},
 		},
 	}, clientSpanRecorder.Ended())
@@ -1064,6 +1083,7 @@ func TestClientHandlerOpts(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingMethod),
+				semconv.RPCGRPCStatusCodeKey.Int64(0),
 			},
 		},
 	}, clientSpanRecorder.Ended())
@@ -1222,6 +1242,7 @@ func TestInterceptors(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingMethod),
+				semconv.RPCGRPCStatusCodeKey.Int64(0),
 			},
 		},
 		{
@@ -1250,6 +1271,7 @@ func TestInterceptors(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingMethod),
+				semconv.RPCGRPCStatusCodeKey.Int64(0),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1439,8 +1461,12 @@ func TestUnaryInterceptorNotModifiedError(t *testing.T) {
 			codeAttributes = append(codeAttributes, attr)
 		}
 	}
-	// should not be any RPC status attribute, only the HTTP status attribute
-	expectedCodeAttributes := []attribute.KeyValue{semconv.HTTPStatusCodeKey.Int(304)}
+	// should not be any RPC error status attribute, only the HTTP status attribute
+	// and the RPC status code attribute should be 0
+	expectedCodeAttributes := []attribute.KeyValue{
+		semconv.HTTPStatusCodeKey.Int(304),
+		semconv.RPCGRPCStatusCodeKey.Int64(0),
+	}
 	assert.Equal(t, expectedCodeAttributes, codeAttributes)
 }
 
@@ -1686,6 +1712,7 @@ func TestStreamingHandlerTracing(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingStreamMethod),
+				semconv.RPCGRPCStatusCodeKey.Int64(0),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1738,6 +1765,7 @@ func TestStreamingClientTracing(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingStreamMethod),
+				semconv.RPCGRPCStatusCodeKey.Int64(0),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1797,6 +1825,7 @@ func TestWithAttributeFilter(t *testing.T) {
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCMethodKey.String(PingStreamMethod),
+				semconv.RPCGRPCStatusCodeKey.Int64(0),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1847,6 +1876,7 @@ func TestWithoutServerPeerAttributes(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingStreamMethod),
+				semconv.RPCGRPCStatusCodeKey.Int64(0),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1919,6 +1949,7 @@ func TestWithoutTraceEventsStreaming(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingStreamMethod),
+				semconv.RPCGRPCStatusCodeKey.Int64(0),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1948,6 +1979,7 @@ func TestWithoutTraceEventsUnary(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingMethod),
+				semconv.RPCGRPCStatusCodeKey.Int64(0),
 			},
 		},
 	}, spanRecorder.Ended())

--- a/streaming.go
+++ b/streaming.go
@@ -86,9 +86,7 @@ func (s *streamingState) receive(ctx context.Context, msg any, conn sendReceiver
 		s.error = err
 		// If error add it to the attributes because the stream is about to terminate.
 		// If no error don't add anything because status only exists at end of stream.
-		if statusCode, ok := statusCodeAttribute(s.protocol, err); ok {
-			s.addAttributes(statusCode)
-		}
+		s.addAttributes(statusCodeAttributes(true, err)...)
 	}
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)
@@ -111,9 +109,7 @@ func (s *streamingState) send(ctx context.Context, msg any, conn sendReceiver) e
 		s.error = err
 		// If error add it to the attributes because the stream is about to terminate.
 		// If no error don't add anything because status only exists at end of stream.
-		if statusCode, ok := statusCodeAttribute(s.protocol, err); ok {
-			s.addAttributes(statusCode)
-		}
+		s.addAttributes(statusCodeAttributes(true, err)...)
 	}
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)

--- a/streaming.go
+++ b/streaming.go
@@ -86,7 +86,7 @@ func (s *streamingState) receive(ctx context.Context, msg any, conn sendReceiver
 		s.error = err
 		// If error add it to the attributes because the stream is about to terminate.
 		// If no error don't add anything because status only exists at end of stream.
-		s.addAttributes(statusCodeAttributes(true, err)...)
+		s.addAttributes(addStatusCodeAttributes(make([]attribute.KeyValue, 0, 2), true, err)...)
 	}
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)
@@ -109,7 +109,7 @@ func (s *streamingState) send(ctx context.Context, msg any, conn sendReceiver) e
 		s.error = err
 		// If error add it to the attributes because the stream is about to terminate.
 		// If no error don't add anything because status only exists at end of stream.
-		s.addAttributes(statusCodeAttributes(true, err)...)
+		s.addAttributes(addStatusCodeAttributes(make([]attribute.KeyValue, 0, 2), true, err)...)
 	}
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)


### PR DESCRIPTION
Resolve #186

Changes:
- Push grpc and connect rpc attributes at the same time.
- Drop grpc web attributes.

The result of `benchstat`

```sh
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: connectrpc.com/otelconnect
cpu: Apple M1 Max
                            │   old.txt   │              new.txt               │
                            │   sec/op    │   sec/op     vs base               │
StreamingBase-10              71.91µ ± 6%   71.19µ ± 8%       ~ (p=0.631 n=10)
StreamingWithInterceptor-10   73.40µ ± 2%   73.22µ ± 1%       ~ (p=0.579 n=10)
UnaryBase-10                  45.37µ ± 3%   45.04µ ± 4%       ~ (p=0.579 n=10)
UnaryWithInterceptor-10       45.86µ ± 1%   45.83µ ± 1%       ~ (p=0.796 n=10)
geomean                       57.57µ        57.27µ       -0.51%

                            │    old.txt    │               new.txt               │
                            │     B/op      │     B/op      vs base               │
StreamingBase-10              24.82Ki ± 10%   26.58Ki ± 6%       ~ (p=0.165 n=10)
StreamingWithInterceptor-10   31.35Ki ±  6%   31.59Ki ± 4%       ~ (p=0.280 n=10)
UnaryBase-10                  19.85Ki ±  7%   19.52Ki ± 5%       ~ (p=0.247 n=10)
UnaryWithInterceptor-10       24.07Ki ±  2%   24.29Ki ± 4%       ~ (p=0.393 n=10)
geomean                       24.69Ki         25.12Ki       +1.73%

                            │  old.txt   │               new.txt               │
                            │ allocs/op  │ allocs/op   vs base                 │
StreamingBase-10              172.0 ± 0%   172.0 ± 0%       ~ (p=1.000 n=10) ¹
StreamingWithInterceptor-10   233.0 ± 0%   233.0 ± 0%       ~ (p=1.000 n=10) ¹
UnaryBase-10                  152.0 ± 0%   152.0 ± 0%       ~ (p=1.000 n=10) ¹
UnaryWithInterceptor-10       202.0 ± 0%   202.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                       187.3        187.3       +0.00%
¹ all samples are equal
```