### PR TITLE
Add WithPropagateResponseHeader option

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -154,7 +154,7 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			if span.IsRecording() {
 				span.SetAttributes(headerAttributes(protocol, responseKey, response.Header(), i.config.responseHeaderKeys)...)
 			}
-			if !isClient && i.config.injectTraceParentResponseHeader {
+			if !isClient && i.config.propagateResponseHeader {
 				responseCarrier := propagation.HeaderCarrier(response.Header())
 				i.config.propagator.Inject(ctx, responseCarrier)
 			}
@@ -315,13 +315,13 @@ func (i *Interceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) co
 			traceOpts...,
 		)
 		defer span.End()
-		
+
 		// Inject traceparent into response headers if enabled
-		if i.config.injectTraceParentResponseHeader {
+		if i.config.propagateResponseHeader {
 			responseCarrier := propagation.HeaderCarrier(conn.ResponseHeader())
 			i.config.propagator.Inject(ctx, responseCarrier)
 		}
-		
+
 		streamingHandler := &streamingHandlerInterceptor{
 			StreamingHandlerConn: conn,
 			receive: func(msg any, conn connect.StreamingHandlerConn) error {

--- a/interceptor.go
+++ b/interceptor.go
@@ -154,6 +154,10 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			if span.IsRecording() {
 				span.SetAttributes(headerAttributes(protocol, responseKey, response.Header(), i.config.responseHeaderKeys)...)
 			}
+			if !isClient && i.config.injectTraceParentResponseHeader {
+				responseCarrier := propagation.HeaderCarrier(response.Header())
+				i.config.propagator.Inject(ctx, responseCarrier)
+			}
 		}
 		if !i.config.omitTraceEvents && span.IsRecording() {
 			span.AddEvent(messageKey,
@@ -311,6 +315,13 @@ func (i *Interceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) co
 			traceOpts...,
 		)
 		defer span.End()
+		
+		// Inject traceparent into response headers if enabled
+		if i.config.injectTraceParentResponseHeader {
+			responseCarrier := propagation.HeaderCarrier(conn.ResponseHeader())
+			i.config.propagator.Inject(ctx, responseCarrier)
+		}
+		
 		streamingHandler := &streamingHandlerInterceptor{
 			StreamingHandlerConn: conn,
 			receive: func(msg any, conn connect.StreamingHandlerConn) error {

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -2270,7 +2270,7 @@ func TestPropagateResponseHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that the traceparent header is present in the response
-	traceparent := response.Header().Get("traceparent")
+	traceparent := response.Header().Get("Traceparent")
 	assert.NotEmpty(t, traceparent, "traceparent header should be present in response")
 
 	// Validate traceparent
@@ -2311,14 +2311,14 @@ func TestPropagateResponseHeaderStreaming(t *testing.T) {
 	require.NoError(t, stream.CloseResponse())
 
 	// Check that the traceparent header is present in the response headers
-	traceparent := stream.ResponseHeader().Get("traceparent")
+	traceparent := stream.ResponseHeader().Get("Traceparent")
 	assert.NotEmpty(t, traceparent, "traceparent header should be present in streaming response")
 
 	// Validate traceparent
 	assertUsableTraceparent(t, stream.ResponseHeader())
 }
 
-// assertUsableTraceparent validates that a traceparent header can be used fromthe response
+// assertUsableTraceparent validates that a traceparent header can be used fromthe response.
 func assertUsableTraceparent(t *testing.T, header http.Header) {
 	t.Helper()
 

--- a/option.go
+++ b/option.go
@@ -126,11 +126,11 @@ func WithoutTraceEvents() Option {
 	return &omitTraceEventsOption{}
 }
 
-// WithTraceParentResponseHeader enables injecting the traceparent header
+// WithPropagateResponseHeader enables injecting the traceparent header
 // into response headers for server-side interceptors. This allows clients
 // to correlate their requests with server-side traces.
-func WithTraceParentResponseHeader() Option {
-	return &traceParentResponseHeaderOption{}
+func WithPropagateResponseHeader() Option {
+	return &propagateResponseHeaderOption{}
 }
 
 type attributeFilterOption struct {
@@ -219,8 +219,8 @@ func (o *omitTraceEventsOption) apply(c *config) {
 	c.omitTraceEvents = true
 }
 
-type traceParentResponseHeaderOption struct{}
+type propagateResponseHeaderOption struct{}
 
-func (o *traceParentResponseHeaderOption) apply(c *config) {
-	c.injectTraceParentResponseHeader = true
+func (o *propagateResponseHeaderOption) apply(c *config) {
+	c.propagateResponseHeader = true
 }

--- a/option.go
+++ b/option.go
@@ -126,6 +126,13 @@ func WithoutTraceEvents() Option {
 	return &omitTraceEventsOption{}
 }
 
+// WithTraceParentResponseHeader enables injecting the traceparent header
+// into response headers for server-side interceptors. This allows clients
+// to correlate their requests with server-side traces.
+func WithTraceParentResponseHeader() Option {
+	return &traceParentResponseHeaderOption{}
+}
+
 type attributeFilterOption struct {
 	filterAttribute AttributeFilter
 }
@@ -210,4 +217,10 @@ type omitTraceEventsOption struct{}
 
 func (o *omitTraceEventsOption) apply(c *config) {
 	c.omitTraceEvents = true
+}
+
+type traceParentResponseHeaderOption struct{}
+
+func (o *traceParentResponseHeaderOption) apply(c *config) {
+	c.injectTraceParentResponseHeader = true
 }

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -36,15 +36,15 @@ const (
 )
 
 type config struct {
-	filter                        func(context.Context, connect.Spec) bool
-	filterAttribute               AttributeFilter
-	meter                         metric.Meter
-	tracer                        trace.Tracer
-	propagator                    propagation.TextMapPropagator
-	now                           func() time.Time
-	trustRemote                   bool
-	requestHeaderKeys             []string
-	responseHeaderKeys            []string
-	omitTraceEvents               bool
-	injectTraceParentResponseHeader bool
+	filter                  func(context.Context, connect.Spec) bool
+	filterAttribute         AttributeFilter
+	meter                   metric.Meter
+	tracer                  trace.Tracer
+	propagator              propagation.TextMapPropagator
+	now                     func() time.Time
+	trustRemote             bool
+	requestHeaderKeys       []string
+	responseHeaderKeys      []string
+	omitTraceEvents         bool
+	propagateResponseHeader bool
 }

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -36,14 +36,15 @@ const (
 )
 
 type config struct {
-	filter             func(context.Context, connect.Spec) bool
-	filterAttribute    AttributeFilter
-	meter              metric.Meter
-	tracer             trace.Tracer
-	propagator         propagation.TextMapPropagator
-	now                func() time.Time
-	trustRemote        bool
-	requestHeaderKeys  []string
-	responseHeaderKeys []string
-	omitTraceEvents    bool
+	filter                        func(context.Context, connect.Spec) bool
+	filterAttribute               AttributeFilter
+	meter                         metric.Meter
+	tracer                        trace.Tracer
+	propagator                    propagation.TextMapPropagator
+	now                           func() time.Time
+	trustRemote                   bool
+	requestHeaderKeys             []string
+	responseHeaderKeys            []string
+	omitTraceEvents               bool
+	injectTraceParentResponseHeader bool
 }


### PR DESCRIPTION
WithTraceParentResponseHeader enables injecting the traceparent header into response headers for server-side interceptors. This allows clients to correlate their requests with server-side traces.