### PR TITLE
Avoid some calls if span is non recording

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21.x,1.22.x,1.23.x]
+        go-version: [1.23.x,1.24.x,1.25.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -30,5 +30,5 @@ jobs:
       - name: Lint
         # Often, lint & gofmt guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
-        if: matrix.go-version == '1.23.x'
+        if: matrix.go-version == '1.25.x'
         run: make checkgenerate && make lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ matrix.go-version.version }}
       - name: Test
         run: make test
       - name: Lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.x,1.24.x,1.25.x]
+        go-version:
+          - name: latest
+            version: 1.25.x
+          - name: previous
+            version: 1.24.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -30,5 +34,5 @@ jobs:
       - name: Lint
         # Often, lint & gofmt guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
-        if: matrix.go-version == '1.25.x'
+        if: matrix.go-version.name == 'latest'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,66 +1,79 @@
-linters-settings:
-  dupl:
-    threshold: 200
-  errcheck:
-    check-type-assertions: true
-  exhaustruct:
-    include:
-      # No zero values for param structs.
-      - 'connectrpc\.com/otelconnect\..*[pP]arams'
-  forbidigo:
-    forbid:
-      - '^fmt\.Print'
-      - '^log\.'
-      - '^print$'
-      - '^println$'
-      - '^panic$'
-  importas:
-    no-unaliased: true
-    alias:
-      - pkg: connectrpc.com/otelconnect/internal/gen/observability/ping/v1
-        alias: pingv1
-  godox:
-    # TODO, OPT, etc. comments are fine to commit. Use FIXME comments for
-    # temporary hacks, and use godox to prevent committing them.
-    keywords: [FIXME]
-  varnamelen:
-    ignore-decls:
-      - T any
-      - i int
-      - wg sync.WaitGroup
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
-    - gofumpt           # prefer standard gofmt
-    - goimports         # rely on gci instead
     - inamedparam       # convention is not followed
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
     - mnd               # status codes are clearer than constants
     - nlreturn          # generous whitespace violates house style
+    - noinlineerr
     - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
     - protogetter       # too many false positives
-    - tenv              # replaced by usetesting
     - testpackage       # internal tests are fine
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
-issues:
-  exclude-dirs-use-default: false
-  exclude:
-    # Don't ban use of fmt.Errorf to create new errors, but the remaining
-    # checks from err113 are useful.
-    - "do not define dynamic errors, use wrapped static errors instead: .*"
-
-  exclude-rules:
-    # If-else is clearer than switch here.
-    - linters: [gocritic]
-      path: trace.go
-    # interceptor_test tests a lot of data structure equality so naturally there are
-    # a lot of duplications
-    - path: interceptor_test.go
-      linters: [dupl]
+    - wsl_v5            # generous whitespace violates house style
+  settings:
+    dupl:
+      threshold: 200
+    errcheck:
+      check-type-assertions: true
+    exhaustruct:
+      include:
+        # No zero values for param structs.
+        - connectrpc\.com/otelconnect\..*[pP]arams
+    forbidigo:
+      forbid:
+        - pattern: ^fmt\.Print
+        - pattern: ^log\.
+        - pattern: ^print$
+        - pattern: ^println$
+        - pattern: ^panic$
+    godox:
+      # TODO, OPT, etc. comments are fine to commit. Use FIXME comments for
+      # temporary hacks, and use godox to prevent committing them.
+      keywords:
+        - FIXME
+    importas:
+      alias:
+        - pkg: connectrpc.com/otelconnect/internal/gen/observability/ping/v1
+          alias: pingv1
+      no-unaliased: true
+    varnamelen:
+      ignore-decls:
+        - T any
+        - i int
+        - wg sync.WaitGroup
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # If-else is clearer than switch here.
+      - linters:
+          - gocritic
+        path: trace.go
+      # interceptor_test tests a lot of data structure equality so naturally there are
+      # a lot of duplications
+      - linters:
+          - dupl
+        path: interceptor_test.go
+      # Don't ban use of fmt.Errorf to create new errors, but the remaining
+      # checks from err113 are useful.
+      - path: (.+)\.go$
+        text: 'do not define dynamic errors, use wrapped static errors instead: .*'
+formatters:
+  enable:
+    - gci
+    - gofmt
+  exclusions:
+    generated: lax

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
 BIN := $(abspath .tmp/bin)
+BUF_VERSION := 1.56.0
 COPYRIGHT_YEARS := 2022-2025
+GOLANGCI_VERSION := 2.4.0
 LICENSE_IGNORE := -e /gen/
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
@@ -37,6 +39,7 @@ build: generate ## Build all packages
 .PHONY: lint
 lint: $(BIN)/golangci-lint $(BIN)/buf ## Lint Go and protobuf
 	test -z "$$($(BIN)/buf format -d . | tee /dev/stderr)"
+	$(BIN)/golangci-lint fmt --diff
 	$(GO) vet ./...
 	$(BIN)/golangci-lint run
 	$(BIN)/buf lint
@@ -44,6 +47,7 @@ lint: $(BIN)/golangci-lint $(BIN)/buf ## Lint Go and protobuf
 .PHONY: lintfix
 lintfix: $(BIN)/golangci-lint $(BIN)/buf ## Automatically fix some lint errors
 	$(BIN)/golangci-lint run --fix
+	$(BIN)/golangci-lint fmt
 	$(BIN)/buf format -w .
 
 .PHONY: generate
@@ -80,16 +84,16 @@ $(BIN)/protoc-gen-connect-go: go.mod
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.50.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v$(BUF_VERSION)
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.50.0
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v$(BUF_VERSION)
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_VERSION)
 
 $(BIN)/protoc-gen-go: Makefile
 	@mkdir -p $(@D)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module connectrpc.com/otelconnect
 
-go 1.21
-
-toolchain go1.23.2
+go 1.23
 
 require (
 	connectrpc.com/connect v1.17.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/otelconnect
 
-go 1.23
+go 1.24
 
 require (
 	connectrpc.com/connect v1.17.0

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1258,7 +1258,7 @@ func TestInterceptors(t *testing.T) {
 func TestUnaryHandlerNoTraceParent(t *testing.T) {
 	t.Parallel()
 	assertTraceParent := func(_ context.Context, req *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
-		assert.Zero(t, req.Header().Get(TraceParentKey))
+		assert.Empty(t, req.Header().Get(TraceParentKey))
 		return connect.NewResponse(&pingv1.PingResponse{Id: req.Msg.GetId()}), nil
 	}
 	serverInterceptor, err := NewInterceptor(
@@ -1280,7 +1280,7 @@ func TestStreamingHandlerNoTraceParent(t *testing.T) {
 		Data: []byte("Hello, otel!"),
 	}
 	assertTraceParent := func(_ context.Context, stream *connect.BidiStream[pingv1.PingStreamRequest, pingv1.PingStreamResponse]) error {
-		assert.Zero(t, stream.RequestHeader().Get(TraceParentKey))
+		assert.Empty(t, stream.RequestHeader().Get(TraceParentKey))
 		return stream.Send(msg)
 	}
 	serverInterceptor, err := NewInterceptor(
@@ -1580,7 +1580,7 @@ func TestStreamingClientPropagation(t *testing.T) {
 		Data: []byte("Hello, otel!"),
 	}
 	assertTraceParent := func(_ context.Context, stream *connect.BidiStream[pingv1.PingStreamRequest, pingv1.PingStreamResponse]) error {
-		assert.NotZero(t, stream.RequestHeader().Get(TraceParentKey))
+		assert.NotEmpty(t, stream.RequestHeader().Get(TraceParentKey))
 		require.NoError(t, stream.Send(msg))
 		return nil
 	}


### PR DESCRIPTION
Update the interceptor to bypass some calls if the span is non-recording. Update buf and golangci-lint to the latest version.