### PR TITLE
Fix ci job names to only include the go-version name, not version number

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ permissions:
   contents: read
 jobs:
   ci:
+    name: ci (go:${{ matrix.go-version.name }})
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This way, we can mark "ci (go:latest)" and "ci (go:previous)" as required checks and never have to change them again. Without an explicit name, it defaults to the job key ("ci") plus the properties of the matrix. So this was using names like "ci (latest, v1.25.x)", which still has the Go version in it, which we don't want.