### PR TITLE
Add Philip Warren as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,7 @@ Maintainers
 ## Current
 * [Josh Humphries](https://github.com/jhump), [Buf](https://buf.build)
 * [Edward McFarlane](https://github.com/emcfarlane), [Buf](https://buf.build)
+* [Philip Warren](https://github.com/pkwarren), [Buf](https://buf.build)
 
 ## Former
 * [Akshay Shah](https://github.com/akshayjshah)


### PR DESCRIPTION
Philip is a maintainer of Connect-Kotlin, very strong in Go, has made contributions to this repo for performance improvements, and is very familiar with OpenTelemetry including the Go runtime library for it. I propose that he be added as an official maintainer here.