### PR TITLE
Update `otel_scope_version`

### DIFF
--- a/otelconnect.go
+++ b/otelconnect.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	version             = "0.8.1"
+	version             = "0.8.1-dev"
 	semanticVersion     = "semver:" + version
 	instrumentationName = "connectrpc.com/otelconnect"
 	grpcProtocol        = "grpc"


### PR DESCRIPTION
The `otel_scope_version` in the metrics emitted by otelconnect-go does not match the actual otelconnect-go version. Perhaps this value should match the library version.

```
rpc_server_request_size_bytes_bucket{otel_scope_name="connectrpc.com/otelconnect",otel_scope_version="semver:0.6.0-dev"} 
```