### PR TITLE
Fix use header attributes only in trace

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -99,9 +99,9 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		carrier := propagation.HeaderCarrier(request.Header())
 		spanKind := trace.SpanKindClient
 		requestSpan, responseSpan := semconv.MessageTypeSent, semconv.MessageTypeReceived
-		attributes = addHeaderAttributes(attributes, protocol, requestKey, request.Header(), i.config.requestHeaderKeys)
+		attributesTrace := addHeaderAttributes(attributes, protocol, requestKey, request.Header(), i.config.requestHeaderKeys)
 		traceOpts := make([]trace.SpanStartOption, 0, 4)
-		traceOpts = append(traceOpts, trace.WithAttributes(attributes...))
+		traceOpts = append(traceOpts, trace.WithAttributes(attributesTrace...))
 		if !isClient {
 			spanKind = trace.SpanKindServer
 			requestSpan, responseSpan = semconv.MessageTypeReceived, semconv.MessageTypeSent


### PR DESCRIPTION
This is fixes for issue of WithTraceRequestHeader option should only give attributes to traces not metrics.

**Header attribute handling:**

* Updated tests to ensure that header attributes are correctly included in tracing spans but not in metrics, including explicit assertions for the absence of header metadata in metrics.

* https://github.com/connectrpc/otelconnect-go/issues/197#issue-3541153984
