### PR TITLE
Add ability to add custom attributes

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -15,6 +15,7 @@
 package otelconnect
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -30,6 +31,8 @@ import (
 // and [attribute.KeyValue]. If the filter returns true the attribute will be
 // kept else it will be removed. AttributeFilter must be safe to call concurrently.
 type AttributeFilter func(connect.Spec, attribute.KeyValue) bool
+
+type CustomAttributes func(context.Context, connect.AnyRequest) []attribute.KeyValue
 
 func (filter AttributeFilter) filter(spec connect.Spec, values ...attribute.KeyValue) []attribute.KeyValue {
 	if filter == nil {

--- a/option.go
+++ b/option.go
@@ -84,6 +84,10 @@ func WithAttributeFilter(filter AttributeFilter) Option {
 	return &attributeFilterOption{filterAttribute: filter}
 }
 
+func WithCustomAttributes(customAttributes CustomAttributes) Option {
+	return &customAttributesOption{customAttributes: customAttributes}
+}
+
 // WithoutServerPeerAttributes removes net.peer.port and net.peer.name
 // attributes from server trace and span attributes. The default behavior
 // follows the OpenTelemetry semantic conventions for RPC, but produces very
@@ -179,6 +183,16 @@ type attributeFilterOption struct {
 func (o *attributeFilterOption) apply(c *config) {
 	if o.filterAttribute != nil {
 		c.filterAttribute = o.filterAttribute
+	}
+}
+
+type customAttributesOption struct {
+	customAttributes CustomAttributes
+}
+
+func (o *customAttributesOption) apply(c *config) {
+	if o.customAttributes != nil {
+		c.customAttributes = o.customAttributes
 	}
 }
 

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -40,6 +40,7 @@ const (
 type config struct {
 	filter                  func(context.Context, connect.Spec) bool
 	filterAttribute         AttributeFilter
+	customAttributes        CustomAttributes
 	meter                   metric.Meter
 	tracer                  trace.Tracer
 	propagator              propagation.TextMapPropagator


### PR DESCRIPTION
This PR adds a `WithCustomAttributes` option to the interceptor that allows you to dynamically add custom attributes to spans and metrics based on the request and context.