### PR TITLE
Prepare for release v0.9.0

### DIFF
--- a/otelconnect.go
+++ b/otelconnect.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	version             = "0.8.1-dev"
+	version             = "0.9.0"
 	semanticVersion     = "semver:" + version
 	instrumentationName = "connectrpc.com/otelconnect"
 


### PR DESCRIPTION
Looks like we've been forgetting to update this constant since v0.6.0. Doh! 🤦

Below are the release notes I intend to include for the release.

----

## What's Changed
### Additions
* Add option to force uniform output in servers that handle both ConnectRPC and gRPC traffic by @jhump in #196

### Bugfixes
* Fix version reported by `otel_scope_version` attribute by @wata727 in #193
* Fix use header attributes only in trace by @rytsh in #198

## New Contributors
* @wata727 made their first contribution in #193
* @rytsh made their first contribution in #198

**Full Changelog**: https://github.com/connectrpc/otelconnect-go/compare/v0.8.0...v0.9.0