### PR TITLE
Add Timo Stamm to maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,6 +5,7 @@ Maintainers
 * [Josh Humphries](https://github.com/jhump), [Buf](https://buf.build)
 * [Edward McFarlane](https://github.com/emcfarlane), [Buf](https://buf.build)
 * [Philip Warren](https://github.com/pkwarren), [Buf](https://buf.build)
+* [Timo Stamm](https://github.com/timostamm), [Buf](https://buf.build)
 
 ## Former
 * [Akshay Shah](https://github.com/akshayjshah)


### PR DESCRIPTION
This adds @timostamm to the set of maintainers in this repo. Timo is the primary author and maintainer of [protobuf-es](https://github.com/bufbuild/protobuf-es) and [connect-es](https://github.com/connectrpc/connect-es). He has demonstrated a clear mastery of ConnectRPC, gRPC, and Protobuf and would be valuable as an additional asset for improving and reviewing improvements for all implementations, including extensions to the Go runtime like this one.