### PR TITLE
Remove retired Go report card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ otelconnect
 ===========
 
 [![Build](https://github.com/connectrpc/otelconnect-go/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/connectrpc/otelconnect-go/actions/workflows/ci.yaml)
-[![Report Card](https://goreportcard.com/badge/connectrpc.com/otelconnect)](https://goreportcard.com/report/connectrpc.com/otelconnect)
 [![GoDoc](https://pkg.go.dev/badge/connectrpc.com/otelconnect.svg)][godoc]
 
 `connectrpc.com/otelconnect` adds support for [OpenTelemetry][opentelemetry.io]


### PR DESCRIPTION
Removed the Report Card badge from the README. See https://github.com/connectrpc/connect-go/pull/942/