### PR TITLE
Omit server peer attributes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ will create child spans for each request.
 
 ## Reducing metrics and tracing cardinality
 
-By default, the [OpenTelemetry RPC conventions][otel-rpc-conventions] produce
-high-cardinality server-side metric and tracing output. In particular, servers
-tag all metrics and trace data with the server's IP address and the remote port
-number. To drop these attributes, use
-[`otelconnect.WithoutServerPeerAttributes`][WithoutServerPeerAttributes]. For
-more customizable attribute filtering, use
-[otelconnect.WithFilter][WithFilter].
+Following the [OpenTelemetry RPC conventions][otel-rpc-conventions], servers can
+tag all metrics and trace data with the remote client's host name (`net.peer.name`)
+and port (`net.peer.port`). Because these identify each individual client, they
+produce extremely high-cardinality output. For this reason, `otelconnect` **omits
+the server-side peer attributes by default**. If you need them and can accept the
+added cardinality, opt back in with
+[`otelconnect.WithServerPeerAttributes`][WithServerPeerAttributes]. For more
+customizable attribute filtering, use [otelconnect.WithFilter][WithFilter].
 
 ## Status
 
@@ -128,7 +129,7 @@ Offered under the [Apache 2 license][license].
 [Buf Studio]: https://buf.build/studio
 [WithFilter]: https://pkg.go.dev/connectrpc.com/otelconnect#WithFilter
 [WithTrustRemote]: https://pkg.go.dev/connectrpc.com/otelconnect#WithTrustRemote
-[WithoutServerPeerAttributes]: https://pkg.go.dev/connectrpc.com/otelconnect#WithoutServerPeerAttributes
+[WithServerPeerAttributes]: https://pkg.go.dev/connectrpc.com/otelconnect#WithServerPeerAttributes
 [blog]: https://buf.build/blog/connect-a-better-grpc
 [conformance]: https://github.com/connectrpc/conformance
 [connect]: https://github.com/connectrpc/connect-go

--- a/attributes.go
+++ b/attributes.go
@@ -62,9 +62,11 @@ func addProcedureAttributes(attrs []attribute.KeyValue, procedure string) []attr
 	return attrs
 }
 
-func addRequestAttributes(protocol string, attrs []attribute.KeyValue, spec connect.Spec, peer connect.Peer) []attribute.KeyValue {
-	if addr := peer.Addr; addr != "" {
-		attrs = addAddressAttributes(attrs, addr)
+func addRequestAttributes(includePeer bool, protocol string, attrs []attribute.KeyValue, spec connect.Spec, peer connect.Peer) []attribute.KeyValue {
+	if includePeer {
+		if addr := peer.Addr; addr != "" {
+			attrs = addAddressAttributes(attrs, addr)
+		}
 	}
 	name := strings.TrimLeft(spec.Procedure, "/")
 	attrs = append(attrs, semconv.RPCSystemKey.String(protocol))

--- a/interceptor.go
+++ b/interceptor.go
@@ -99,7 +99,8 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		name := strings.TrimLeft(request.Spec().Procedure, "/")
 		protocol := protocolToSemConv(request.Peer().Protocol, i.config.rpcSystem)
 		attributes := make([]attribute.KeyValue, 0, 6+len(i.config.requestHeaderKeys)) // 5 max request attrs + status code attr + headers
-		attributes = attributeFilter(request.Spec(), addRequestAttributes(protocol, attributes, request.Spec(), request.Peer())...)
+		includePeer := isClient || i.config.serverPeerAttributes
+		attributes = attributeFilter(request.Spec(), addRequestAttributes(includePeer, protocol, attributes, request.Spec(), request.Peer())...)
 		instrumentation := i.getInstruments(isClient)
 		carrier := propagation.HeaderCarrier(request.Header())
 		spanKind := trace.SpanKindClient
@@ -222,6 +223,7 @@ func (i *Interceptor) WrapStreamingClient(next connect.StreamingClientFunc) conn
 		i.config.propagator.Inject(ctx, carrier)
 		protocol := protocolToSemConv(conn.Peer().Protocol, i.config.rpcSystem)
 		state := newStreamingState(
+			spec.IsClient || i.config.serverPeerAttributes,
 			protocol,
 			spec,
 			conn.Peer(),
@@ -304,6 +306,7 @@ func (i *Interceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) co
 		name := strings.TrimLeft(conn.Spec().Procedure, "/")
 		protocol := protocolToSemConv(conn.Peer().Protocol, i.config.rpcSystem)
 		state := newStreamingState(
+			conn.Spec().IsClient || i.config.serverPeerAttributes,
 			protocol,
 			conn.Spec(),
 			conn.Peer(),

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -84,7 +84,7 @@ func TestStreamingMetrics(t *testing.T) {
 		}),
 	)
 	require.NoError(t, err)
-	connectClient, host, port := startServer(t,
+	connectClient, _, _ := startServer(t,
 		[]connect.HandlerOption{
 			connect.WithInterceptors(interceptor),
 		}, []connect.ClientOption{}, okayPingServer())
@@ -117,8 +117,6 @@ func TestStreamingMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerNameKey.String(host),
-										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(connectProtocol),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(pingStreamMethod),
@@ -140,8 +138,6 @@ func TestStreamingMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerNameKey.String(host),
-										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(connectProtocol),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(pingStreamMethod),
@@ -163,8 +159,6 @@ func TestStreamingMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerNameKey.String(host),
-										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(connectProtocol),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(pingStreamMethod),
@@ -186,8 +180,6 @@ func TestStreamingMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerNameKey.String(host),
-										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(connectProtocol),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(pingStreamMethod),
@@ -209,8 +201,6 @@ func TestStreamingMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerNameKey.String(host),
-										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(connectProtocol),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(pingStreamMethod),
@@ -584,7 +574,7 @@ func TestStreamingMetricsFail(t *testing.T) {
 		}),
 	)
 	require.NoError(t, err)
-	connectClient, host, port := startServer(t,
+	connectClient, _, _ := startServer(t,
 		[]connect.HandlerOption{
 			connect.WithInterceptors(interceptor),
 		}, []connect.ClientOption{}, failPingServer())
@@ -618,8 +608,6 @@ func TestStreamingMetricsFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerNameKey.String(host),
-										semconv.NetPeerPortKey.Int(port),
 										attribute.Key(rpcConnectErrorCode).String("data_loss"),
 										semconv.RPCSystemKey.String(connectProtocol),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -642,8 +630,6 @@ func TestStreamingMetricsFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerNameKey.String(host),
-										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(connectProtocol),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(pingStreamMethod),
@@ -665,8 +651,6 @@ func TestStreamingMetricsFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerNameKey.String(host),
-										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(connectProtocol),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(pingStreamMethod),
@@ -689,8 +673,6 @@ func TestStreamingMetricsFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerNameKey.String(host),
-										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(connectProtocol),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(pingStreamMethod),
@@ -1232,7 +1214,7 @@ func TestInterceptors(t *testing.T) {
 		WithTraceRequestHeader("X-Request-Id"),
 	)
 	require.NoError(t, err)
-	pingClient, host, port := startServer(t, []connect.HandlerOption{
+	pingClient, _, _ := startServer(t, []connect.HandlerOption{
 		connect.WithInterceptors(serverInterceptor),
 	}, nil, okayPingServer())
 	pingWithHeader := requestOfSize(1, 0)
@@ -1265,8 +1247,6 @@ func TestInterceptors(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerNameKey.String(host),
-				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(connectProtocol),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(pingMethod),
@@ -1294,8 +1274,6 @@ func TestInterceptors(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerNameKey.String(host),
-				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(connectProtocol),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(pingMethod),
@@ -1705,7 +1683,7 @@ func TestStreamingHandlerTracing(t *testing.T) {
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
 	serverInterceptor, err := NewInterceptor(WithTracerProvider(traceProvider))
 	require.NoError(t, err)
-	pingClient, host, port := startServer(t, []connect.HandlerOption{
+	pingClient, _, _ := startServer(t, []connect.HandlerOption{
 		connect.WithInterceptors(serverInterceptor, assertSpanInterceptor{t: t}),
 	}, nil, okayPingServer())
 	stream := pingClient.PingStream(context.Background())
@@ -1743,8 +1721,6 @@ func TestStreamingHandlerTracing(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerNameKey.String(host),
-				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(connectProtocol),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(pingStreamMethod),
@@ -1914,6 +1890,58 @@ func TestWithoutServerPeerAttributes(t *testing.T) {
 	}, spanRecorder.Ended())
 }
 
+func TestWithServerPeerAttributes(t *testing.T) {
+	t.Parallel()
+	spanRecorder := tracetest.NewSpanRecorder()
+	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
+	serverInterceptor, err := NewInterceptor(
+		WithTracerProvider(traceProvider),
+		WithServerPeerAttributes(),
+	)
+	require.NoError(t, err)
+	pingClient, host, port := startServer(t, []connect.HandlerOption{
+		connect.WithInterceptors(serverInterceptor),
+	}, nil, okayPingServer())
+	stream := pingClient.PingStream(context.Background())
+	msg := &pingv1.PingStreamRequest{Data: []byte("Hello, otel!")}
+	size := proto.Size(msg)
+	require.NoError(t, stream.Send(msg))
+	_, err = stream.Receive()
+	require.NoError(t, err)
+	require.NoError(t, stream.CloseRequest())
+	require.NoError(t, stream.CloseResponse())
+	assertSpans(t, []wantSpans{
+		{
+			spanName: pingv1connect.PingServiceName + "/" + pingStreamMethod,
+			events: []trace.Event{
+				{
+					Name: messageKey,
+					Attributes: []attribute.KeyValue{
+						semconv.MessageTypeReceived,
+						semconv.MessageIDKey.Int(1),
+						semconv.MessageUncompressedSizeKey.Int(size),
+					},
+				},
+				{
+					Name: messageKey,
+					Attributes: []attribute.KeyValue{
+						semconv.MessageTypeSent,
+						semconv.MessageIDKey.Int(1),
+						semconv.MessageUncompressedSizeKey.Int(size),
+					},
+				},
+			},
+			attrs: []attribute.KeyValue{
+				semconv.NetPeerNameKey.String(host),
+				semconv.NetPeerPortKey.Int(port),
+				semconv.RPCSystemKey.String(connectProtocol),
+				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
+				semconv.RPCMethodKey.String(pingStreamMethod),
+			},
+		},
+	}, spanRecorder.Ended())
+}
+
 func TestStreamingSpanStatus(t *testing.T) {
 	t.Parallel()
 	var propagator propagation.TraceContext
@@ -1960,7 +1988,7 @@ func TestWithoutTraceEventsStreaming(t *testing.T) {
 		WithoutTraceEvents(),
 	)
 	require.NoError(t, err)
-	pingClient, host, port := startServer(t, []connect.HandlerOption{
+	pingClient, _, _ := startServer(t, []connect.HandlerOption{
 		connect.WithInterceptors(serverInterceptor),
 	}, nil, okayPingServer())
 	stream := pingClient.PingStream(context.Background())
@@ -1976,8 +2004,6 @@ func TestWithoutTraceEventsStreaming(t *testing.T) {
 			spanName: pingv1connect.PingServiceName + "/" + pingStreamMethod,
 			events:   []trace.Event{},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerNameKey.String(host),
-				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(connectProtocol),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(pingStreamMethod),
@@ -1995,7 +2021,7 @@ func TestWithoutTraceEventsUnary(t *testing.T) {
 		WithoutTraceEvents(),
 	)
 	require.NoError(t, err)
-	pingClient, host, port := startServer(t, []connect.HandlerOption{
+	pingClient, _, _ := startServer(t, []connect.HandlerOption{
 		connect.WithInterceptors(serverInterceptor),
 	}, nil, okayPingServer())
 	_, err = pingClient.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{Id: 1}))
@@ -2005,8 +2031,6 @@ func TestWithoutTraceEventsUnary(t *testing.T) {
 			spanName: pingv1connect.PingServiceName + "/" + pingMethod,
 			events:   []trace.Event{},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerNameKey.String(host),
-				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(connectProtocol),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(pingMethod),

--- a/option.go
+++ b/option.go
@@ -19,11 +19,9 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
@@ -84,24 +82,23 @@ func WithAttributeFilter(filter AttributeFilter) Option {
 	return &attributeFilterOption{filterAttribute: filter}
 }
 
+// WithServerPeerAttributes adds the net.peer.name and net.peer.port attributes
+// to server trace and metric output. These attributes follow the OpenTelemetry
+// semantic conventions for RPC, but because they identify the remote client they
+// produce very high-cardinality data. They are omitted by default; use this
+// option to opt back in when the cardinality is acceptable in your environment.
+func WithServerPeerAttributes() Option {
+	return &serverPeerAttributesOption{}
+}
+
 // WithoutServerPeerAttributes removes net.peer.port and net.peer.name
-// attributes from server trace and span attributes. The default behavior
-// follows the OpenTelemetry semantic conventions for RPC, but produces very
-// high-cardinality data; this option significantly reduces cardinality in most
-// environments.
+// attributes from server trace and metric output.
+//
+// Deprecated: server peer attributes are now omitted by default, so this option
+// is a no-op. Use [WithServerPeerAttributes] to opt back in to the previous
+// behavior.
 func WithoutServerPeerAttributes() Option {
-	return WithAttributeFilter(func(spec connect.Spec, value attribute.KeyValue) bool {
-		if spec.IsClient {
-			return true
-		}
-		if value.Key == semconv.NetPeerPortKey {
-			return false
-		}
-		if value.Key == semconv.NetPeerNameKey {
-			return false
-		}
-		return true
-	})
+	return &emptyOption{}
 }
 
 // WithTrustRemote sets the Interceptor to trust remote spans.
@@ -263,6 +260,17 @@ type propagateResponseHeaderOption struct{}
 func (o *propagateResponseHeaderOption) apply(c *config) {
 	c.propagateResponseHeader = true
 }
+
+type serverPeerAttributesOption struct{}
+
+func (o *serverPeerAttributesOption) apply(c *config) {
+	c.serverPeerAttributes = true
+}
+
+// emptyOption is a no-op Option
+type emptyOption struct{}
+
+func (o *emptyOption) apply(*config) {}
 
 type rpcSystemOption struct {
 	system RPCSystem

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -49,5 +49,6 @@ type config struct {
 	responseHeaderKeys      []string
 	omitTraceEvents         bool
 	propagateResponseHeader bool
+	serverPeerAttributes    bool
 	rpcSystem               RPCSystem
 }

--- a/streaming.go
+++ b/streaming.go
@@ -45,6 +45,7 @@ type streamingState struct {
 }
 
 func newStreamingState(
+	includePeer bool,
 	protocol string,
 	spec connect.Spec,
 	peer connect.Peer,
@@ -55,7 +56,7 @@ func newStreamingState(
 ) *streamingState {
 	attributes := make([]attribute.KeyValue, 0, 6) // 5 max request attrs + status code attr
 	attributes = attributeFilter.filter(spec,
-		addRequestAttributes(protocol, attributes, spec, peer)...,
+		addRequestAttributes(includePeer, protocol, attributes, spec, peer)...,
 	)
 	return &streamingState{
 		spec:            spec,


### PR DESCRIPTION
By default `net.peer.name` and `net.peer.port` are included with metrics and traces. These identify the remote client, so on a busy server they produce extremely high-cardinality output. The only mitigation was the opt-out `WithoutServerPeerAttributes()`, which users (e.g. myself) discover only after cardinality had already blown up their metrics backend.

The affected server metrics are all histograms (`rpc.server.duration`,
`.request.size`, `.response.size`, `.requests_per_rpc`, `.responses_per_rpc`).
[Datadog bills a histogram as 5 custom metrics](https://docs.datadoghq.com/account_management/billing/custom_metrics/) per unique tag combination, at
[$5 per 100 custom metrics/month ($0.05 each)](https://www.datadoghq.com/pricing/list/).

`net.peer.port` is an ephemeral client source port, so every distinct client
connection becomes its own set of series: 5 histograms x 5 = 25 billed custom
metrics ≈ $1.25/month **per distinct client ip:port**, on top of the normal
method/status/host cardinality.

| Distinct client ip:port / hr | Billed custom metrics | Added cost / month |
|---:|---:|---:|
| 1,000 | 25,000 | $1,250 |
| 10,000 | 250,000 | $12,500 |
| 100,000 | 2,500,000 | $125,000 |

A single moderately-busy service (~10k distinct client connections/hr) can add
~$12,500/month in Datadog custom-metric charges purely from the default server
peer attributes — which is why they should be opt-in.
(Datadog custom-metrics pricing, July 2026.)

Flip the default so the low-cardinality behavior is the default, and add `WithServerPeerAttributes()` for callers who want to opt back in. 

`WithoutServerPeerAttributes()` can now be deprecated is a no-op, since its behavior is the new default.

Relates to #48 and #50.